### PR TITLE
Add missing metadata composer 2/2

### DIFF
--- a/dev-php/semver/metadata.xml
+++ b/dev-php/semver/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+    Semantic versioning utilities with the addition of version constraints parsing and checking.
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/spdx-licenses/metadata.xml
+++ b/dev-php/spdx-licenses/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+	Tools for working with the SPDX license list and validating licenses. 
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/symfony-config/metadata.xml
+++ b/dev-php/symfony-config/metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+  	The Config component provides several classes to help you find, load, combine,
+	autofill and validate configuration values of any kind,
+	whatever their source may be (YAML, XML, INI files, or for instance a database).
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/symfony-console/metadata.xml
+++ b/dev-php/symfony-console/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+  	The Console component eases the creation of beautiful and testable command line interfaces.
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/symfony-dependency-injection/metadata.xml
+++ b/dev-php/symfony-dependency-injection/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+  	The DependencyInjection component allows you to standardize
+	and centralize the way objects are constructed in your application.
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/symfony-event-dispatcher/metadata.xml
+++ b/dev-php/symfony-event-dispatcher/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+	The EventDispatcher component provides tools that allow your application components
+	to communicate with each other by dispatching events and listening to them.
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/symfony-process/metadata.xml
+++ b/dev-php/symfony-process/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+  	The Process component executes commands in sub-processes.
+  </longdescription>
+</pkgmetadata>

--- a/dev-php/symfony-yaml/metadata.xml
+++ b/dev-php/symfony-yaml/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>guillaumeseren@gmail.com</email>
+    <name>Guillaume Seren</name>
+  </maintainer>
+  <longdescription>
+  	The Yaml component loads and dumps YAML files.
+  </longdescription>
+</pkgmetadata>


### PR DESCRIPTION
Fix remaining repoman issues \o/
```
RepoMan does a once-over of the neighborhood...
[INFO] checking package dev-php/ca-bundle
[INFO] checking package dev-php/cli-prompt
[INFO] checking package dev-php/composer
[INFO] checking package dev-php/fedora-autoloader
[INFO] checking package dev-php/fig-log
[INFO] checking package dev-php/json-schema
[INFO] checking package dev-php/jsonlint
[INFO] checking package dev-php/phar-utils
[INFO] checking package dev-php/phpunit
[INFO] checking package dev-php/semver
[INFO] checking package dev-php/spdx-licenses
[INFO] checking package dev-php/symfony-config
[INFO] checking package dev-php/symfony-console
[INFO] checking package dev-php/symfony-dependency-injection
[INFO] checking package dev-php/symfony-event-dispatcher
[INFO] checking package dev-php/symfony-filesystem
[INFO] checking package dev-php/symfony-finder
[INFO] checking package dev-php/symfony-process
[INFO] checking package dev-php/symfony-yaml

Note: use --include-dev (-d) to check dependencies for 'dev' profiles

RepoMan sez: "If everyone were like you, I'd be out of business!"
```