### PR TITLE
dev-php/psr-cache: Fix 1.0.1 ebuild

### DIFF
--- a/dev-php/psr-cache/psr-cache-1.0.1.ebuild
+++ b/dev-php/psr-cache/psr-cache-1.0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 DESCRIPTION="PSR Cache interfaces defined by PSR-6"
 HOMEPAGE="https://github.com/php-fig/cache"
-https://github.com/php-fig/cache/archive/1.0.1.tar.gz
+# https://github.com/php-fig/cache/archive/1.0.1.tar.gz
 SRC_URI="https://github.com/php-fig/cache/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Remove url of the tar that break the ebuild