### PR TITLE
dev-ruby/eventmachine: Fix wrong stable flag

### DIFF
--- a/dev-ruby/eventmachine/eventmachine-1.2.7-r1.ebuild
+++ b/dev-ruby/eventmachine/eventmachine-1.2.7-r1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://github.com/eventmachine/eventmachine/archive/v${PV}.tar.gz -> $
 
 LICENSE="|| ( GPL-2 Ruby )"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
 IUSE=""
 
 DEPEND="${DEPEND}


### PR DESCRIPTION
Signed-off-by: Guillaume Seren <guillaumeseren@gmail.com>