### PR TITLE
dev-ruby/vagrant_cloud: Add missing rdepend log4r

### DIFF
--- a/dev-ruby/vagrant_cloud/vagrant_cloud-3.0.2.ebuild
+++ b/dev-ruby/vagrant_cloud/vagrant_cloud-3.0.2.ebuild
@@ -20,7 +20,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 IUSE="test"
 
-ruby_add_rdepend ">=dev-ruby/excon-0.73"
+ruby_add_rdepend "
+	>=dev-ruby/excon-0.73
+	>=dev-ruby/log4r-1.1.10
+"
 ruby_add_bdepend ">=dev-ruby/rake-12.3
 	test? (
 		>=dev-ruby/webmock-3.0


### PR DESCRIPTION
Signed-off-by: Guillaume Seren <guillaumeseren@gmail.com>